### PR TITLE
Changed parser to ignore Online Quick ratings.

### DIFF
--- a/lib/UscfWebsite.rb
+++ b/lib/UscfWebsite.rb
@@ -112,7 +112,7 @@ class UscfWebsite
       end
       
       quickBlocks.each do |block|
-        if (block.text.include?("=>") && ratings[:quick] == 0)
+        if (block.text.include?("=>") && ratings[:quick] == 0 && !(block.text.include?("ONL:")))
           ratings[:quick] = block.text[block.text.index("=>") + 2, block.text.length].strip.to_i
           break
         end


### PR DESCRIPTION
The USCF added Online Quick rated tournaments. As the Online Quick
rating is different from the Quick rating, Online Quick ratings should
not be included in the Quick rating category. Dg